### PR TITLE
Little extension over the Ruby 1.9 spawn interface...

### DIFF
--- a/lib/posix/spawn.rb
+++ b/lib/posix/spawn.rb
@@ -501,7 +501,7 @@ module POSIX
         [['/bin/sh', '/bin/sh'], '-c', args[0]]
       elsif !args[0].respond_to?(:to_ary)
         # [argv0, argv1, ...]
-        [[args[0], args[0]], *args[1..-1]]
+        [[args[0], args[0]], *(args[1..-1].flatten.collect { |arg| arg.to_s })]
       else
         # [[cmdname, argv0], argv1, ...]
         args


### PR DESCRIPTION
This allows calling POSIX::Spawn#spawn() with parameters without explicitly
converting them as string, as well as including arrays of arguments, so
that the following syntax is accepted:

i = 123
a = [ "foo", "bar" ]
spawn("echo", i, a, { :in => :close })