### PR TITLE
As of Rubygems 1.7.0, `Gem::Specification#has_rdoc=` has been deprecated

### DIFF
--- a/posix-spawn.gemspec
+++ b/posix-spawn.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.description = 'posix-spawn uses posix_spawnp(2) for faster process spawning'
 
   s.homepage = 'http://github.com/rtomayko/posix-spawn'
-  s.has_rdoc = false
 
   s.authors = ['Ryan Tomayko', 'Aman Gupta']
   s.email = ['r@tomayko.com', 'aman@tmm1.net']


### PR DESCRIPTION
`has_rdoc=` has been deprecated (see http://blog.segment7.net/2011/04/01/rubygems-1-7-0 for example). So it's better to remove it to avoid future breakage.
