### PR TITLE
Circular require

### DIFF
--- a/lib/posix/spawn/child.rb
+++ b/lib/posix/spawn/child.rb
@@ -1,5 +1,3 @@
-require 'posix/spawn'
-
 module POSIX
   module Spawn
     # POSIX::Spawn::Child includes logic for executing child processes and


### PR DESCRIPTION
1.9 doesn't like circular requires. The readme shows `require 'posix/spawn'` loading `POSIX::Spawn::Child` so I preserved that behavior. This would break standalone `require 'posix/spawn/child'`. Not sure if you consider that public. Another workaround would be making `Child` an autoload in `POSIX::Spawn`.
