### PR TITLE
Stop compilation of native code on cygwin

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -3,7 +3,7 @@ require 'mkmf'
 # warnings save lives
 $CFLAGS << " -Wall "
 
-if RUBY_PLATFORM =~ /(mswin|mingw|bccwin)/
+if RUBY_PLATFORM =~ /(mswin|mingw|cygwin|bccwin)/
   File.open('Makefile','w'){|f| f.puts "default: \ninstall: " }
 else
   create_makefile('posix_spawn_ext')

--- a/lib/posix/spawn.rb
+++ b/lib/posix/spawn.rb
@@ -1,4 +1,4 @@
-unless RUBY_PLATFORM =~ /(mswin|mingw|bccwin)/
+unless RUBY_PLATFORM =~ /(mswin|mingw|cygwin|bccwin)/
   require 'posix_spawn_ext'
 end
 


### PR DESCRIPTION
This fix adds a check for cygwin to the RUBY_PLATFORM checks when building or requiring the native extensions.
