### PR TITLE
Try SIGKILL if the process doesn't respond to SIGTERM

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,8 @@ task :default => :test
 
 GEMSPEC = eval(File.read('posix-spawn.gemspec'))
 
-require 'rake/gempackagetask'
-Rake::GemPackageTask.new(GEMSPEC) do |pkg|
+require 'rubygems/package_task'
+Gem::PackageTask.new(GEMSPEC) do |pkg|
 end
 
 # ==========================================================


### PR DESCRIPTION
As noted in a comment on #7, this allows test_max_with_stubborn_child to
pass on OSX. However, the test still leaves an orphaned `yes` process.
That's issue #26 -- not sure how to fix it.