### PR TITLE
Version bump to 0.3.7 for Windows backtick fix

### DIFF
--- a/lib/posix/spawn/version.rb
+++ b/lib/posix/spawn/version.rb
@@ -1,5 +1,5 @@
 module POSIX
   module Spawn
-    VERSION = '0.3.6'
+    VERSION = '0.3.7'
   end
 end


### PR DESCRIPTION
re: https://github.com/rtomayko/posix-spawn/pull/35, I think this will fix a potentially-related issue for Windows users with pygments.rb
