### PR TITLE
Check for IO::set_encoding support

### DIFF
--- a/lib/posix/spawn/child.rb
+++ b/lib/posix/spawn/child.rb
@@ -146,7 +146,7 @@ module POSIX
         offset = 0
 
         # force all string and IO encodings to BINARY under 1.9 for now
-        if out.respond_to?(:force_encoding)
+        if out.respond_to?(:force_encoding) and stdin.respond_to?(:set_encoding)
           [stdin, stdout, stderr].each do |fd|
             fd.set_encoding('BINARY', 'BINARY')
           end


### PR DESCRIPTION
See edge case described here, for details: https://github.com/jsvine/gekyll/commit/6228e0e3
