### PR TITLE
show more context for spawnp error message

### DIFF
--- a/ext/posix-spawn.c
+++ b/ext/posix-spawn.c
@@ -438,8 +438,10 @@ rb_posixspawn_pspawn(VALUE self, VALUE env, VALUE argv, VALUE options)
 	}
 
 	if (ret != 0) {
+		char error_context[PATH_MAX+32];
+		snprintf(error_context, sizeof(error_context), "when spawning '%s'", file);
 		errno = ret;
-		rb_sys_fail("posix_spawnp");
+		rb_sys_fail(error_context);
 	}
 
 	return INT2FIX(pid);


### PR DESCRIPTION
The old error message was

`No such file or directory - posix_spawnp`

That confuses people into thinking that they're missing a dependency called posix_spawnp, when what's actually happened is that posix_spawnp returned ENOENT when trying to execute, um, something.  Ruby locks us into this `strerror + " - " + function` ordering that is opposite the `function + ": " + strerror` order that people are used to, and that `perror` provides.

The new error message just piles more information into the `mesg` field, like so:

`No such file or directory - when spawning 'xxgh-gitmon'`
