### PR TITLE
add LGPL license metadata to gemspec

### DIFF
--- a/posix-spawn.gemspec
+++ b/posix-spawn.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.authors = ['Ryan Tomayko', 'Aman Gupta']
   s.email = ['r@tomayko.com', 'aman@tmm1.net']
-  s.license = 'MIT'
+  s.licenses = ['MIT', 'LGPL']
 
   s.add_development_dependency 'rake-compiler', '0.7.6'
 


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to correctly report the licenses for your gem.
