### PR TITLE
Support Windows when not using backtick execution

### DIFF
--- a/lib/posix/spawn.rb
+++ b/lib/posix/spawn.rb
@@ -268,6 +268,7 @@ module POSIX
     #
     # Returns the String output of the command.
     def `(cmd)
+      r, w = IO.pipe
       pid = spawn(*system_command_prefixes, cmd, :out => w, r => :close)
 
       if pid > 0


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll/issues/2556

/cc @piki
