### PR TITLE
Document chdir the behavior of posix-spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ These `Process::spawn` arguments are currently supported to any of
         :unsetenv_others => true   : clear environment variables except specified by env
         :unsetenv_others => false  : don't clear (default)
       current directory:
-        :chdir => str
+        :chdir => str : Not thread-safe when using posix_spawn (see below)
       process group:
         :pgroup => true or 0 : make a new process group
         :pgroup => pgid      : join to specified process group
@@ -242,6 +242,13 @@ These options are currently NOT supported:
       file descriptor inheritance: close non-redirected non-standard fds (3, 4, 5, ...) or not
         :close_others => false : inherit fds (default for system and exec)
         :close_others => true  : don't inherit (default for spawn and IO.popen)
+
+The `:chdir` option provided by Posix::Spawn::Child, Posix::Spawn#spawn,
+Posix::Spawn#system and Posix::Spawn#popen4 is not thread-safe because
+processes spawned with the posix_spawn(2) system call inherit the working
+directory of the calling process. The posix-spawn gem works around this
+limitation in the system call by changing the working directory of the calling
+process immediately before and after spawning the child process.
 
 ## ACKNOWLEDGEMENTS
 

--- a/lib/posix/spawn.rb
+++ b/lib/posix/spawn.rb
@@ -79,7 +79,9 @@ module POSIX
   # When a hash is given in the last argument (options), it specifies a
   # current directory and zero or more fd redirects for the child process.
   #
-  # The :chdir option specifies the current directory:
+  # The :chdir option specifies the current directory. Note that :chdir is not
+  # thread-safe on systems that provide posix_spawn(2), because it forces a
+  # temporary change of the working directory of the calling process.
   #
   #     spawn(command, :chdir => "/var/tmp")
   #


### PR DESCRIPTION
Not knowing exactly what posix_spawn(2) does and does not do for you, I was a little surprised when I found out that the posix-spawn gem changes the working directory of the calling process. This commit is an attempt to share what I have learned.
