### PR TITLE
Only apply -Wall for GCC.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,7 +1,7 @@
 require 'mkmf'
 
 # warnings save lives
-$CFLAGS << " -Wall "
+$CFLAGS << " -Wall " if RbConfig::CONFIG['GCC'] != ""
 
 if RUBY_PLATFORM =~ /(mswin|mingw|cygwin|bccwin)/
   File.open('Makefile','w'){|f| f.puts "default: \ninstall: " }


### PR DESCRIPTION
The Solaris Studio C compiler chokes on this flag.
