### PR TITLE
Better error message when rake-compiler gem is missing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,13 @@ end
 # Ruby Extension
 # ==========================================================
 
-require 'rake/extensiontask'
+begin
+  require 'rake/extensiontask'
+rescue LoadError => boom
+  warn "ERROR: The rake-compiler gem dependency is missing."
+  warn "Please run `bundle install' and try again."
+  raise
+end
 Rake::ExtensionTask.new('posix_spawn_ext', GEMSPEC) do |ext|
   ext.ext_dir = 'ext'
 end


### PR DESCRIPTION
Reported in https://github.com/rtomayko/posix-spawn/issues/31. When building or running tests locally and the rake-compiler gem isn't installed, rake blows up with:

```
$ rake
rake aborted!
LoadError: cannot load such file -- rake/extensiontask
/Users/rtomayko/github/posix-spawn/Rakefile:18:in `<top (required)>'
(See full trace by running task with --trace)
```

This PR gives more detail on which gem is missing and suggests running `bundle install`:

```
$ rake
ERROR: The rake-compiler gem dependency is missing.
Please run `bundle install' and try again.
rake aborted!
```