### PR TITLE
POSIX::Spawn::Child sends TERM to whole process group on timeout / error

### DIFF
--- a/lib/posix/spawn/child.rb
+++ b/lib/posix/spawn/child.rb
@@ -134,6 +134,11 @@ module POSIX
       # Total command execution time (wall-clock time)
       attr_reader :runtime
 
+      # The pid of the spawned child process. This is unlikely to be a valid
+      # current pid since Child#exec! doesn't return until the process finishes
+      # and is reaped.
+      attr_reader :pid
+
       # Determine if the process did exit with a zero exit status.
       def success?
         @status && @status.success?
@@ -145,6 +150,7 @@ module POSIX
       def exec!
         # spawn the process and hook up the pipes
         pid, stdin, stdout, stderr = popen4(@env, *(@argv + [@options]))
+        @pid = pid
 
         # async read from all streams into buffers
         read_and_write(@input, stdin, stdout, stderr, @timeout, @max)

--- a/lib/posix/spawn/child.rb
+++ b/lib/posix/spawn/child.rb
@@ -160,8 +160,11 @@ module POSIX
       rescue Object => boom
         [stdin, stdout, stderr].each { |fd| fd.close rescue nil }
         if @status.nil?
-          kill_pid = @pgroup_kill ? pid * -1 : pid
-          ::Process.kill('TERM', kill_pid) rescue nil
+          if !@pgroup_kill
+            ::Process.kill('TERM', pid) rescue nil
+          else
+            ::Process.kill('-TERM', pid) rescue nil
+          end
           @status = waitpid(pid) rescue nil
         end
         raise

--- a/lib/posix/spawn/child.rb
+++ b/lib/posix/spawn/child.rb
@@ -79,9 +79,7 @@ module POSIX
       #                        MaximumOutputExceeded exception.
       #   :pgroup_kill => bool Boolean specifying whether to kill the process
       #                        group (true) or individual process (false, default).
-      #                        Note that `:pgroup => true` must also be
-      #                        specified when this option is set true so that
-      #                        the new process gets its a new process group.
+      #                        Setting this option true implies :pgroup => true.
       #
       # Returns a new Child instance whose underlying process has already
       # executed to completion. The out, err, and status attributes are
@@ -92,7 +90,10 @@ module POSIX
         @input = @options.delete(:input)
         @timeout = @options.delete(:timeout)
         @max = @options.delete(:max)
-        @pgroup_kill = @options.delete(:pgroup_kill)
+        if @options.delete(:pgroup_kill)
+          @pgroup_kill = true
+          @options[:pgroup] = true
+        end
         @options.delete(:chdir) if @options[:chdir].nil?
         exec! if !@options.delete(:noexec)
       end

--- a/test/test_child.rb
+++ b/test/test_child.rb
@@ -61,15 +61,33 @@ class ChildTest < Minitest::Test
     end
   end
 
+  def test_max_pgroup_kill
+    assert_raises MaximumOutputExceeded do
+      Child.new('yes', :max => 100_000, :pgroup => true, :pgroup_kill => true)
+    end
+  end
+
   def test_max_with_child_hierarchy
     assert_raises MaximumOutputExceeded do
       Child.new('/bin/sh', '-c', 'yes', :max => 100_000)
     end
   end
 
+  def test_max_with_child_hierarchy_pgroup_kill
+    assert_raises MaximumOutputExceeded do
+      Child.new('/bin/sh', '-c', 'yes', :max => 100_000, :pgroup => true, :pgroup_kill => true)
+    end
+  end
+
   def test_max_with_stubborn_child
     assert_raises MaximumOutputExceeded do
       Child.new("trap '' TERM; yes", :max => 100_000)
+    end
+  end
+
+  def test_max_with_stubborn_child_pgroup_kill
+    assert_raises MaximumOutputExceeded do
+      Child.new("trap '' TERM; yes", :max => 100_000, :pgroup => true, :pgroup_kill => true)
     end
   end
 
@@ -98,9 +116,23 @@ class ChildTest < Minitest::Test
     assert (Time.now-start) <= 0.2
   end
 
+  def test_timeout_pgroup_kill
+    start = Time.now
+    assert_raises TimeoutExceeded do
+      Child.new('sleep', '1', :timeout => 0.05, :pgroup => true, :pgroup_kill => true)
+    end
+    assert (Time.now-start) <= 0.2
+  end
+
   def test_timeout_with_child_hierarchy
     assert_raises TimeoutExceeded do
       Child.new('/bin/sh', '-c', 'sleep 1', :timeout => 0.05)
+    end
+  end
+
+  def test_timeout_with_child_hierarchy_pgroup_kill
+    assert_raises TimeoutExceeded do
+      Child.new('/bin/sh', '-c', 'sleep 1', :timeout => 0.05, :pgroup => true, :pgroup_kill => true)
     end
   end
 

--- a/test/test_child.rb
+++ b/test/test_child.rb
@@ -95,7 +95,7 @@ class ChildTest < Minitest::Test
   end
 
   def test_max_pgroup_kill
-    child = Child.build('yes', :max => 100_000, :pgroup => true, :pgroup_kill => true)
+    child = Child.build('yes', :max => 100_000, :pgroup_kill => true)
     assert_raises(MaximumOutputExceeded) { child.exec! }
     assert_process_reaped child.pid
     assert_process_group_reaped child.pid
@@ -109,7 +109,7 @@ class ChildTest < Minitest::Test
   end
 
   def test_max_with_child_hierarchy_pgroup_kill
-    child = Child.build('/bin/sh', '-c', 'true && yes', :max => 100_000, :pgroup => true, :pgroup_kill => true)
+    child = Child.build('/bin/sh', '-c', 'true && yes', :max => 100_000, :pgroup_kill => true)
     assert_raises(MaximumOutputExceeded) { child.exec! }
     assert_process_reaped child.pid
     assert_process_group_reaped child.pid
@@ -123,7 +123,7 @@ class ChildTest < Minitest::Test
   end
 
   def test_max_with_stubborn_child_pgroup_kill
-    child = Child.build("trap '' TERM; yes", :max => 100_000, :pgroup => true, :pgroup_kill => true)
+    child = Child.build("trap '' TERM; yes", :max => 100_000, :pgroup_kill => true)
     assert_raises(MaximumOutputExceeded) { child.exec! }
     assert_process_reaped child.pid
     assert_process_group_reaped child.pid
@@ -161,7 +161,7 @@ class ChildTest < Minitest::Test
 
   def test_timeout_pgroup_kill
     start = Time.now
-    child = Child.build('sleep', '1', :timeout => 0.05, :pgroup => true, :pgroup_kill => true)
+    child = Child.build('sleep', '1', :timeout => 0.05, :pgroup_kill => true)
     assert_raises(TimeoutExceeded) { child.exec! }
     assert_process_reaped child.pid
     assert_process_group_reaped child.pid
@@ -175,7 +175,7 @@ class ChildTest < Minitest::Test
   end
 
   def test_timeout_with_child_hierarchy_pgroup_kill
-    child = Child.build('/bin/sh', '-c', 'true && sleep 1', :timeout => 0.05, :pgroup => true, :pgroup_kill => true)
+    child = Child.build('/bin/sh', '-c', 'true && sleep 1', :timeout => 0.05, :pgroup_kill => true)
     assert_raises(TimeoutExceeded) { child.exec! }
     assert_process_reaped child.pid
     assert_process_group_reaped child.pid
@@ -183,7 +183,7 @@ class ChildTest < Minitest::Test
 
   def test_timeout_with_partial_output
     start = Time.now
-    p = Child.build('echo Hello; sleep 1', :timeout => 0.05, :pgroup => true, :pgroup_kill => true)
+    p = Child.build('echo Hello; sleep 1', :timeout => 0.05, :pgroup_kill => true)
     assert_raises(TimeoutExceeded) { p.exec! }
     assert_process_reaped p.pid
     assert_process_group_reaped Process.pid


### PR DESCRIPTION
This adds a `:pgroup_kill` option to POSIX::Spawn::Child. When both `:pgroup => true` and `:pgroup_kill => true` are set, an exception like TimeoutExceeded or MaximumOutputExceeded will cause `SIGTERM` to be sent to the whole child process group instead of just the immediate child process.

Need tests here and I'm still not sure I love this combination of args just yet. I think we should raise ArgumentError if `:pgroup_kill => true` and `:pgroup` is unset or set to something other than true at least.

/cc @github/gitrpc, @piki, @adelcambre, https://github.com/github/gitrpc/pull/369, https://github.com/github/ops/issues/4263