### PR TITLE
Replace libc code with clean room implementation

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -20,9 +20,3 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER  IN  AN
 ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN  THE
 SOFTWARE.
-
-A small portion of the environ dup'ing code in ext/posix-spawn.c
-was taken from glibc <http://www.gnu.org/s/libc/> and is maybe
-Copyright (c) 2011 by The Free Software Foundation or maybe
-by others mentioned in the glibc LICENSES file. glibc is
-distributed under the terms of the LGPL license.

--- a/posix-spawn.gemspec
+++ b/posix-spawn.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.authors = ['Ryan Tomayko', 'Aman Gupta']
   s.email = ['r@tomayko.com', 'aman@tmm1.net']
-  s.licenses = ['MIT', 'LGPL']
+  s.licenses = ['MIT']
 
   s.add_development_dependency 'rake-compiler', '0.7.6'
   s.add_development_dependency 'minitest', '>= 4'


### PR DESCRIPTION
This replaces the environment dup'ing code from libc (added in 2e19f50c103afa9e684b9d2f388403286c478289) with a clean room implementation.

/cc @rtomayko @tmm1 @talniv