### PR TITLE
Add support for streaming stdout/stderr from Child invocations

### DIFF
--- a/lib/posix/spawn.rb
+++ b/lib/posix/spawn.rb
@@ -337,6 +337,10 @@ module POSIX
     class TimeoutExceeded < StandardError
     end
 
+    # Exception raised when output streaming is aborted early.
+    class Aborted < StandardError
+    end
+
     private
 
     # Turns the various varargs incantations supported by Process::spawn into a

--- a/lib/posix/spawn/child.rb
+++ b/lib/posix/spawn/child.rb
@@ -260,20 +260,25 @@ module POSIX
               fd.close
             end
 
+            abort = false
             if chunk
               if fd == stdout
                 if @streaming && @stdout_block
-                  @stdout_block.call(chunk)
+                  abort = !!@stdout_block.call(chunk)
                 else
                   @out << chunk
                 end
               else
                 if @streaming && @stderr_block
-                  @stderr_block.call(chunk)
+                  abort = !!@stderr_block.call(chunk)
                 else
                   @err << chunk
                 end
               end
+            end
+
+            if @streaming && abort
+              raise Aborted
             end
           end
 

--- a/test/test_child.rb
+++ b/test/test_child.rb
@@ -224,6 +224,36 @@ class ChildTest < Minitest::Test
     assert p.success?
   end
 
+  def test_streaming_stdout
+    stdout_buf = ""
+    stdout_stream = Proc.new do |chunk|
+      stdout_buf << chunk
+    end
+
+    input = "hello!"
+    p = Child.new('cat', :input => input, :streams => {
+      :stdout => stdout_stream
+    })
+
+    assert p.success?
+    assert_equal input, stdout_buf
+  end
+
+  def test_streaming_stderr
+    stderr_buf = ""
+    stderr_stream = Proc.new do |chunk|
+      stderr_buf << chunk
+    end
+
+    input = "hello!"
+    p = Child.new('ls', '-?', :input => input, :streams => {
+      :stderr => stderr_stream
+    })
+
+    refute p.success?
+    refute stderr_buf.empty?
+  end
+
   ##
   # Assertion Helpers
 

--- a/test/test_child.rb
+++ b/test/test_child.rb
@@ -228,6 +228,8 @@ class ChildTest < Minitest::Test
     stdout_buf = ""
     stdout_stream = Proc.new do |chunk|
       stdout_buf << chunk
+
+      false
     end
 
     input = "hello!"
@@ -243,15 +245,42 @@ class ChildTest < Minitest::Test
     stderr_buf = ""
     stderr_stream = Proc.new do |chunk|
       stderr_buf << chunk
+
+      false
     end
 
-    input = "hello!"
-    p = Child.new('ls', '-?', :input => input, :streams => {
+    p = Child.new('ls', '-?', :streams => {
       :stderr => stderr_stream
     })
 
     refute p.success?
     refute stderr_buf.empty?
+  end
+
+  def test_streaming_stdout_aborted
+    stdout_stream = Proc.new do |chunk|
+      true
+    end
+
+    input = "hello!"
+    assert_raises POSIX::Spawn::Aborted do
+      p = Child.new('cat', :input => input, :streams => {
+        :stdout => stdout_stream
+      })
+    end
+  end
+
+  def test_streaming_stderr_aborted
+    stderr_stream = Proc.new do |chunk|
+      true
+    end
+
+    input = "hello!"
+    assert_raises POSIX::Spawn::Aborted do
+      p = Child.new('ls', '-?', :streams => {
+        :stderr => stderr_stream
+      })
+    end
   end
 
   ##


### PR DESCRIPTION
As the title says, this adds support for passing a block for receiving chunks of output stdout/stderr as they're being read.

I'm not _super_ happy with how the API turned out, and I could probably add a few more tests - so suggestions are definitely welcome.

@tmm1 @piki @carlosmn @simonsj @vmg @scottjg in case either of you have time to review this 🙏 