### PR TITLE
Replace references to Fixnum with Integer

### DIFF
--- a/ext/posix-spawn.c
+++ b/ext/posix-spawn.c
@@ -45,7 +45,7 @@ static VALUE rb_mPOSIXSpawn;
  *       an actual fd number:
  *         - The symbols :in, :out, or :err for fds 0, 1, or 2.
  *         - An IO object. (IO#fileno is returned)
- *         - A Fixnum.
+ *         - An Integer.
  *
  * Returns the fd number >= 0 if one could be established, or -1 if the object
  * does not map to an fd.
@@ -56,8 +56,12 @@ posixspawn_obj_to_fd(VALUE obj)
 	int fd = -1;
 	switch (TYPE(obj)) {
 		case T_FIXNUM:
-			/* Fixnum fd number */
-			fd = FIX2INT(obj);
+		case T_BIGNUM:
+			/* Integer fd number
+			 * rb_fix2int takes care of raising if the provided object is a
+			 * Bignum and is out of range of an int
+			 */
+			fd = (int)rb_fix2int(obj);
 			break;
 
 		case T_SYMBOL:
@@ -94,7 +98,7 @@ posixspawn_obj_to_fd(VALUE obj)
 /*
  * Hash iterator that sets up the posix_spawn_file_actions_t with addclose
  * operations. Only hash pairs whose value is :close are processed. Keys may
- * be the :in, :out, :err, an IO object, or a Fixnum fd number.
+ * be the :in, :out, :err, an IO object, or an Integer fd number.
  *
  * Returns ST_DELETE when an addclose operation was added; ST_CONTINUE when
  * no operation was performed.

--- a/lib/posix/spawn.rb
+++ b/lib/posix/spawn.rb
@@ -85,7 +85,7 @@ module POSIX
   #
   #     spawn(command, :chdir => "/var/tmp")
   #
-  # The :in, :out, :err, a Fixnum, an IO object or an Array option specify
+  # The :in, :out, :err, an Integer, an IO object or an Array option specify
   # fd redirection. For example, stderr can be merged into stdout as follows:
   #
   #     spawn(command, :err => :out)
@@ -460,11 +460,11 @@ module POSIX
 
     # Determine whether object is fd-like.
     #
-    # Returns true if object is an instance of IO, Fixnum >= 0, or one of the
+    # Returns true if object is an instance of IO, Integer >= 0, or one of the
     # the symbolic names :in, :out, or :err.
     def fd?(object)
       case object
-      when Fixnum
+      when Integer
         object >= 0
       when :in, :out, :err, STDIN, STDOUT, STDERR, $stdin, $stdout, $stderr, IO
         true
@@ -486,7 +486,7 @@ module POSIX
         STDOUT
       when :err, 2
         STDERR
-      when Fixnum
+      when Integer
         object >= 0 ? IO.for_fd(object) : nil
       when IO
         object


### PR DESCRIPTION
Ruby 2.4 [unifies `Fixnum` and `Bignum` into a single `Integer` class](https://bugs.ruby-lang.org/issues/12005).

As of 2.4, referencing the `Fixnum` or `Bignum` constants directly emits a warning.

This pull request replaces all references to `Fixnum` with `Integer`