### PR TITLE
Fix memory leak in env preparation

### DIFF
--- a/ext/posix-spawn.c
+++ b/ext/posix-spawn.c
@@ -283,6 +283,11 @@ each_env_i(VALUE key, VALUE val, VALUE arg)
 		const char *ev = envp[i];
 
 		if (strlen(ev) > name_len && !memcmp(ev, name, name_len) && ev[name_len] == '=') {
+			/* This operates on a duplicated environment -- release the
+			 * existing entry memory before shifting the subsequent entry
+			 * pointers down. */
+			free(envp[i]);
+
 			for (j = i; envp[j]; ++j)
 				envp[j] = envp[j + 1];
 			continue;


### PR DESCRIPTION
Free the existing entry's memory when replacing an existing entry in the
environment. In the calling function (`rb_posixspawn_pspawn`), the processes'
current env is duplicated; each existing environment entry is copied with
`strdup`.

This only occurs if `posix_spawn` is supplied with an environment hash containing keys which collide with existing keys in the environment. If that _is_ the case, each conflicting entry's memory is leaked.

This was the source of a long-standing mysterious memory growth in a few of our services.  🎉 