### PR TITLE
Fix some posix spawn warnings

### DIFF
--- a/lib/posix/spawn.rb
+++ b/lib/posix/spawn.rb
@@ -529,7 +529,7 @@ module POSIX
     #
     # Returns a [[cmdname, argv0], argv1, ...] array.
     def adjust_process_spawn_argv(args)
-      if args.size == 1 && args[0] =~ /[ |>]/
+      if args.size == 1 && args[0].is_a?(String) && args[0] =~ /[ |>]/
         # single string with these characters means run it through the shell
         command_and_args = system_command_prefixes + [args[0]]
         [*command_and_args]

--- a/lib/posix/spawn/child.rb
+++ b/lib/posix/spawn/child.rb
@@ -1,5 +1,3 @@
-require 'posix/spawn'
-
 module POSIX
   module Spawn
     # POSIX::Spawn::Child includes logic for executing child processes and

--- a/test/test_spawn.rb
+++ b/test/test_spawn.rb
@@ -322,7 +322,7 @@ module SpawnImplementationTests
       end
     end
 
-    assert_match /oops/, exception.message
+    assert_match(/oops/, exception.message)
   end
 
   ##


### PR DESCRIPTION
Hello! 👋 

We're seeing the first warning in our app and would like to fix this so that we can continue upgrading Ruby versions. If you don't want the other changes I'm happy to rebase them out since the first Object warning is the only one we actually need to be warning free in our application

This PR fixes 3 warnings coming from Ruby. 

* Fixes `/lib/posix/spawn.rb:532: warning: deprecated Object#=~ is called on Array; it always returns nil` deprecation that appears on Ruby 2.7. This deprecation is also present in application code and not just gem code/test runs
* Fixes `/test/test_spawn.rb:325: warning: ambiguous first argument; put parentheses or a space even after `/' operator` which appears when tests are run.
* Fixes `warning: loading in progress, circular require considered harmful` loading error present in Ruby 2.6 and 2.7.