### PR TITLE
Fix compilation on newer clang

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ task :default => :test
 # Packaging
 # ==========================================================
 
-GEMSPEC = eval(File.read('posix-spawn.gemspec'))
+GEMSPEC = eval(File.read('posix-spawn.gemspec'), binding, __FILE__, __LINE__)
 
 require 'rubygems/package_task'
 Gem::PackageTask.new(GEMSPEC) do |pkg|

--- a/ext/posix-spawn.c
+++ b/ext/posix-spawn.c
@@ -196,8 +196,9 @@ posixspawn_file_actions_addopen(VALUE key, VALUE val, posix_spawn_file_actions_t
  * if not.
  */
 static int
-posixspawn_file_actions_operations_iter(VALUE key, VALUE val, posix_spawn_file_actions_t *fops)
+posixspawn_file_actions_operations_iter(VALUE key, VALUE val, VALUE fops_value)
 {
+    posix_spawn_file_actions_t *fops = (posix_spawn_file_actions_t *)fops_value;
 	int act;
 
 	act = posixspawn_file_actions_addclose(key, val, fops);


### PR DESCRIPTION
```
posix-spawn.c:226:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, posix_spawn_file_actions_t *)' (aka 'int (unsigned long, unsigned long, void **)') to parameter of type 'int
(*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
        rb_hash_foreach(options, posixspawn_file_actions_operations_iter, (VALUE)fops);
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/rubies/3.4-dev-03-19/include/ruby-3.4.0+0/ruby/internal/intern/hash.h:83:40: note: passing argument to parameter 'func' here
void rb_hash_foreach(VALUE hash, int (*func)(VALUE key, VALUE val, VALUE arg), VALUE arg);
```